### PR TITLE
Merge strats: Initial documentation

### DIFF
--- a/examples/merge-strats.md
+++ b/examples/merge-strats.md
@@ -1,0 +1,7 @@
+# PR Merge Strategies
+
+There are 3 merge strategies in GitHub:
+
+1. Merge
+2. Squash and Merge
+3. Rebase and merge

--- a/examples/merge-strats.md
+++ b/examples/merge-strats.md
@@ -5,3 +5,9 @@ There are 3 merge strategies in GitHub:
 1. Merge
 2. Squash and Merge
 3. Rebase and merge
+
+## Rebase and Merge
+
+This is my preferred strategy for small repos with only a handful concurrent contributors. This makes for a linear and clean main tree which for a small team can outweigh the benefits of merge commits.
+
+The caveat here is that it requires a bit of extra overhead for interacting with. 


### PR DESCRIPTION
Setup the base documentation for the 3 primary github merge strats - starting with rebase.

Include a fixup commit to test how the rebase strat interacts with it.